### PR TITLE
Make ONNX inference non-blocking using run_async

### DIFF
--- a/LICENSE-COMMERCIAL
+++ b/LICENSE-COMMERCIAL
@@ -1,4 +1,4 @@
-MNEMOS COMMERCIAL LICENSE
+MEMLORD COMMERCIAL LICENSE
 
 Copyright (c) 2026-present Yorsh Siarhei (sergey@memlord.com) and Dmitry Karnei (dmitry@memlord.com).
 

--- a/src/memlord/dao/memory.py
+++ b/src/memlord/dao/memory.py
@@ -83,7 +83,7 @@ class MemoryDao:
                 content=str(content),
                 memory_type=MemoryType(memory_type),
                 extra_data=metadata or {},
-                embedding=embed(_embed_text(content, tags or [])),
+                embedding=await embed(_embed_text(content, tags or [])),
                 created_by=self._uid,
                 workspace_id=workspace_id,
             )
@@ -138,7 +138,7 @@ class MemoryDao:
             )
             if content is not _UNSET:
                 values["content"] = content
-            values["embedding"] = embed(_embed_text(new_content, new_tags))
+            values["embedding"] = await embed(_embed_text(new_content, new_tags))
 
         if values:
             await self._s.execute(

--- a/src/memlord/embeddings.py
+++ b/src/memlord/embeddings.py
@@ -1,3 +1,4 @@
+import asyncio
 from functools import cache
 
 import numpy as np
@@ -20,7 +21,7 @@ def _get_tokenizer() -> Tokenizer:
     return t
 
 
-def embed(text: str) -> list[float]:
+async def embed(text: str) -> list[float]:
     tokenizer = _get_tokenizer()
     session = _get_session()
 
@@ -29,14 +30,27 @@ def embed(text: str) -> list[float]:
     attention_mask = np.array([encoding.attention_mask], dtype=np.int64)
     token_type_ids = np.zeros_like(input_ids, dtype=np.int64)
 
-    outputs = session.run(
+    loop = asyncio.get_running_loop()
+    future: asyncio.Future[list[np.ndarray]] = loop.create_future()
+
+    def _callback(results: list[np.ndarray], _user_data: None, err: str) -> None:
+        if err:
+            loop.call_soon_threadsafe(future.set_exception, RuntimeError(err))
+        else:
+            loop.call_soon_threadsafe(future.set_result, results)
+
+    session.run_async(
         None,
         {
             "input_ids": input_ids,
             "attention_mask": attention_mask,
             "token_type_ids": token_type_ids,
         },
+        _callback,
+        None,
     )
+
+    outputs = await future
 
     # mean pooling with attention mask
     token_embeddings = np.asarray(outputs[0])  # (1, seq_len, 384)

--- a/src/memlord/search.py
+++ b/src/memlord/search.py
@@ -72,7 +72,7 @@ async def hybrid_search(
     bm25_rows = (await session.execute(bm25_q)).fetchall()
 
     # Vector KNN via pgvector cosine distance
-    vector = embed(query)
+    vector = await embed(query)
     vec_param = bindparam("vec", type_=Vector(384))
     distance = Memory.embedding.op("<=>", return_type=Float)(vec_param).label(
         "distance"


### PR DESCRIPTION
  Summary
                                                                                                                                                                                                                                                                                                                            
  - embed() was synchronous, calling InferenceSession.run() which blocked the asyncio event loop during inference                                                                                                                                                                                                         
  - Switched to InferenceSession.run_async(), which offloads computation to ORT's internal C++ intra-op threadpool
  - Bridged the callback-based API to asyncio via asyncio.Future + loop.call_soon_threadsafe() — the coroutine suspends while ORT runs inference in its thread, then resumes when the callback fires
  - Updated all three call sites (dao/memory.py ×2, search.py) to await embed(...)
