### PR TITLE
Add workspace filter param to retrieve_memory and recall_memory

### DIFF
--- a/src/memlord/tools/recall.py
+++ b/src/memlord/tools/recall.py
@@ -23,6 +23,7 @@ async def recall_memory(
     n_results: int = 5,
     memory_type: MemoryType | None = None,
     snippet_length: int | None = 200,
+    workspace: str | None = None,
     s: AsyncSession = MCPSessionDep,  # type: ignore[assignment]
     uid: int = UserDep,  # type: ignore[assignment]
 ) -> list[RecallResult]:
@@ -33,6 +34,7 @@ async def recall_memory(
     Returns compact snippets by default (snippet_length=200). To get the full
     content of a specific memory, call get_memory(id).
     Set snippet_length=None to return full content immediately.
+    Pass workspace=<name> to search only within a specific workspace.
     """
     date_from: datetime | None = None
     date_to: datetime | None = None
@@ -54,7 +56,14 @@ async def recall_memory(
             remaining = remaining.replace(date_str, "")
         semantic_query = remaining.strip() or query
 
-    workspace_ids = await WorkspaceDao(s).get_accessible_workspace_ids(uid)
+    ws_dao = WorkspaceDao(s)
+    if workspace is not None:
+        ws = await ws_dao.get_by_name(workspace, uid)
+        if ws is None:
+            raise ValueError(f"Workspace {workspace!r} not found or not accessible")
+        workspace_ids = [ws.id]
+    else:
+        workspace_ids = await ws_dao.get_accessible_workspace_ids(uid)
     results = await hybrid_search(
         s,
         query=semantic_query,

--- a/src/memlord/tools/retrieve.py
+++ b/src/memlord/tools/retrieve.py
@@ -20,6 +20,7 @@ async def retrieve_memory(
     similarity_threshold: float = 0.7,
     memory_type: MemoryType | None = None,
     snippet_length: int | None = 200,
+    workspace: str | None = None,
     s: AsyncSession = MCPSessionDep,  # type: ignore[assignment]
     uid: int = UserDep,  # type: ignore[assignment]
 ) -> list[MemoryResult]:
@@ -28,8 +29,16 @@ async def retrieve_memory(
     Returns compact snippets by default (snippet_length=200). To get the full
     content of a specific memory, call get_memory(id).
     Set snippet_length=None to return full content immediately.
+    Pass workspace=<name> to search only within a specific workspace.
     """
-    workspace_ids = await WorkspaceDao(s).get_accessible_workspace_ids(uid)
+    ws_dao = WorkspaceDao(s)
+    if workspace is not None:
+        ws = await ws_dao.get_by_name(workspace, uid)
+        if ws is None:
+            raise ValueError(f"Workspace {workspace!r} not found or not accessible")
+        workspace_ids = [ws.id]
+    else:
+        workspace_ids = await ws_dao.get_accessible_workspace_ids(uid)
     results = await hybrid_search(
         s,
         query=query,


### PR DESCRIPTION
- Both retrieve_memory and recall_memory now accept an optional workspace: str | None parameter (default None)
- When provided, the workspace is resolved by name via WorkspaceDao.get_by_name, which already enforces membership — only that workspace's ID is passed to hybrid_search
- When omitted, behavior is unchanged: all accessible workspaces are searched
- Raises ValueError if the named workspace doesn't exist or isn't accessible to the caller